### PR TITLE
use builtin method instead of referencing ExternalModules class

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -65,11 +65,11 @@ class ExternalModule extends AbstractExternalModule {
 
         if ($project_id) {
             $settings = $settings['project-settings'];
-            $values = ExternalModules::getProjectSettingsAsArray($this->PREFIX, $project_id);
+            $values = $this->getProjectSettings($project_id);
         }
         else {
             $settings = $settings['system-settings'];
-            $values = ExternalModules::getSystemSettingsAsArray($this->PREFIX);
+            $values = $this->getSystemSettings();
         }
 
         return $this->_getFormattedSettings($settings, $values);


### PR DESCRIPTION
Addresses issue #7 

Note that prior to this change the module still works, this PR is merely future-proofing.