### PR TITLE
Enable CSS additions to all project pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # REDCap CSS Injector
-Allows administrators to inject CSS into surveys and data entry forms.
+Allows administrators to inject CSS into surveys, data entry forms and other project pages.
 
 [![DOI](https://zenodo.org/badge/141312467.svg)](https://zenodo.org/badge/latestdoi/141312467)
 

--- a/config.json
+++ b/config.json
@@ -1,11 +1,13 @@
 {
     "name": "REDCap CSS Injector",
     "namespace": "CSSInjector\\ExternalModule",
-    "description": "Allow administrators to inject CSS into surveys and data entry forms. <strong><a href=\"https://github.com/ctsit/redcap_css_injector\">See full documentation here</a></strong>.",
+    "description": "Allow administrators to inject CSS into surveys, data entry forms and other project pages. <strong><a href=\"https://github.com/ctsit/redcap_css_injector\">See full documentation here</a></strong>.",
     "permissions": [
         "redcap_data_entry_form_top",
-        "redcap_survey_page_top"
+        "redcap_survey_page_top",
+        "redcap_every_page_top"
     ],
+    "enable-every-page-hooks-on-system-pages": false,
     "authors": [
         {
             "name": "Philip Chase",
@@ -43,15 +45,23 @@
                     "choices": [
                         {
                             "value": "all",
-                            "name": "All"
+                            "name": "All project pages"
                         },
                         {
                             "value": "survey",
-                            "name": "Surveys"
+                            "name": "Surveys only"
                         },
                         {
                             "value": "data_entry",
-                            "name": "Data entries"
+                            "name": "Data entry forms only"
+                        },
+                        {
+                            "value": "both",
+                            "name": "Data entry and survey forms only"
+                        },
+                        {
+                            "value": "non",
+                            "name": "Non-data entry/survey pages"
                         }
                     ]
                 },
@@ -60,7 +70,23 @@
                     "key": "style_forms",
                     "type": "form-list",
                     "repeatable": true,
-                    "select2": true
+                    "branchingLogic": {
+                        "type": "or",
+                        "conditions": [
+                            {
+                                "field": "style_type",
+                                "value": "survey"
+                            },
+                            {
+                                "field": "style_type",
+                                "value": "data_entry"
+                            },
+                            {
+                                "field": "style_type",
+                                "value": "both"
+                            }
+                        ]
+                    }
                 },
                 {
                     "name": "CSS",


### PR DESCRIPTION
Enabling CSS additions to non survey and data entry form project pages.

Hello ctsit team. Thanks very much for this very handy module. I've been using it in production for a while now but there have been a couple of occasions where I wanted to do something on a project page that is not a data entry or survey form. I've made a few tweaks to support that functionality and thought I'd submit them to you so you can take a look and see whether you're interested in incorporating changes along these lines into your repo. No worries if not - my version is working for me! (Actually the branching logic on the form selection is not, but I'm suspecting a framework bug atm...)