### PR TITLE
Enable CSS injection on survey acknowledgement page

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -29,6 +29,13 @@ class ExternalModule extends AbstractExternalModule {
     }
 
     /**
+     * @inheritdoc
+     */
+    function redcap_survey_acknowledgement_page($project_id, $record = null, $instrument, $event_id, $group_id = null, $survey_hash, $response_id = null, $repeat_instance = 1) {
+        $this->applyStyles('survey', $instrument);
+    }
+
+    /**
      * Apply CSS rules.
      *
      * @param string $type

--- a/config.json
+++ b/config.json
@@ -4,7 +4,8 @@
     "description": "Allow administrators to inject CSS into surveys and data entry forms. <strong><a href=\"https://github.com/ctsit/redcap_css_injector\">See full documentation here</a></strong>.",
     "permissions": [
         "redcap_data_entry_form_top",
-        "redcap_survey_page_top"
+        "redcap_survey_page_top",
+        "redcap_survey_acknowledgement_page"
     ],
     "authors": [
         {


### PR DESCRIPTION
This minor addition will allow the injection of css into the survey acknowledgement page, although it doesn't change anything in the module configuration to inform the user of such. 
The redcap_survey_acknowledgement_page hook is only available in REDCap version 10.2.0 or later. I have not changed the redcap-version-min value, and publishing a new version these days requires the framework version in the config as well, so, my apologies, but this PR is not Repo-ready!
